### PR TITLE
export mock synapse

### DIFF
--- a/src/index.mts
+++ b/src/index.mts
@@ -1,3 +1,4 @@
 export * from "./helpers/index.mts";
+export * from "./mock/mock-synapse.module.mts";
 export * from "./services/index.mts";
 export * from "./synapse.module.mts";


### PR DESCRIPTION
## 📬 Changes

[In your documentation you mention](https://docs.digital-alchemy.app/docs/home-automation/testing/synapse#lib_mock_synapse) a helper library that helps synapse work with tests.

We can't use it though, because its not been exported from the package. This PR fixes that.